### PR TITLE
Add homework 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # funbiscuit_platform
 funbiscuit Platform repository
+
+# ДЗ 1
+В kubernetes-intro добавил Dockerfile и nginx.conf для сборки образа веб-сервера, выдающего
+файлы из директории /app.
+
+Для запуска веб-сервера сделан манифест пода web-pod.yaml.
+
+Для проекта Hipster Shop сделан манифест пода frontend: frontend-pod.yaml. Для запуска
+потребовались дополнительные переменные среды (адреса других микросервисов), их добавил
+в манифест frontend-pod-healthy.yaml.

--- a/kubernetes-intro/Dockerfile
+++ b/kubernetes-intro/Dockerfile
@@ -1,0 +1,8 @@
+FROM centos:centos7
+RUN mkdir /app/
+RUN yum -y install epel-release
+RUN yum -y install nginx
+RUN usermod -u 1001 nginx && groupmod -g 1001 nginx
+ADD nginx.conf /etc/nginx/nginx.conf
+EXPOSE 8000
+CMD ["nginx", "-g", "daemon off;"]

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+    - image: funbiscuit/otus-shop-frontend
+      name: frontend
+      env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"
+  restartPolicy: Never

--- a/kubernetes-intro/frontend-pod.yaml
+++ b/kubernetes-intro/frontend-pod.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: funbiscuit/otus-shop-frontend
+    name: frontend
+  restartPolicy: Never

--- a/kubernetes-intro/nginx.conf
+++ b/kubernetes-intro/nginx.conf
@@ -1,0 +1,18 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    include mime.types;
+    index index.html;
+    sendfile on;
+
+    server {
+        listen 8000;
+
+        root /app;
+        location / {
+            try_files $uri $uri/;
+        }
+    }
+}

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web
+  labels:
+    app: web
+spec:
+  initContainers:
+    - name: downloader
+      image: busybox:1.31.0
+      command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh' ]
+      volumeMounts:
+        - name: app
+          mountPath: /app
+  containers:
+    - name: nginx
+      image: funbiscuit/otus-web
+      volumeMounts:
+        - name: app
+          mountPath: /app
+  volumes:
+    - name: app
+      emptyDir:

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -20,4 +20,4 @@ spec:
           mountPath: /app
   volumes:
     - name: app
-      emptyDir:
+      emptyDir: {}


### PR DESCRIPTION
После запуска minikube были доступны следующие поды:
coredns-5d78c9869d-5h6qw
etcd-minikube
kube-apiserver-minikube
kube-controller-manager-minikube
kube-proxy-trtmp
kube-scheduler-minikube

После удаления всех подов они запустились автоматически. Потому что:
1. Под coredns создается из-за наличия deployment (с шаблоном пода), а kube-proxy - из-за наличия daemonset (с шаблоном пода).
2. Поды etcd-minikube, kube-apiserver-minikube, kube-controller-manager-minikube и kube-scheduler-minikube
созданы как статические: yaml манифесты лежат на ноде в /etc/kubernetes/manifests, поэтому тоже создаются
после удаления.